### PR TITLE
Revert dbt s3 ingestion codes to dev version

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/dbt.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt.py
@@ -294,10 +294,20 @@ def load_file_as_json(uri: str) -> Any:
     if re.match("^https?://", uri):
         return json.loads(requests.get(uri).text)
     elif re.match("^s3://", uri):
+        import json
+        import boto3
+        from urllib.parse import urlparse
+        s3 = boto3.resource('s3')
+        u = urlparse(uri)
+        s3_object =  s3.Object(u.netloc, u.path.lstrip('/'))
+        return json.loads(s3_object.get()['Body'].read().decode('utf-8'))
+        
+        '''
         from urllib.parse import urlparse
         s3_client = AwsSourceConfig().get_s3_client()
         u = urlparse(uri)
         return json.loads(s3_client.get_object(Bucket=u.netloc, Key=u.path.lstrip('/'))['Body'].read().decode('utf-8'))
+        '''
     else:
         with open(uri, "r") as f:
             return json.load(f)


### PR DESCRIPTION
The patch is getting complicated and involves recipe change (aws_region is required if datahub uses aws client). 
Let's use the old working codes to get data into datahub prod to take a look at the lineage first. 
Then we can test the new fix in dev env then submit a formal PR to the community.


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
