### PR TITLE
Update glue.py to allow cross-account access

### DIFF
--- a/metadata-ingestion/source_docs/glue.md
+++ b/metadata-ingestion/source_docs/glue.md
@@ -101,6 +101,7 @@ Note that a `.` is used to denote nested fields in the YAML recipe.
 | `domain.domain_key.allow`       |          |              | List of regex patterns for tables to set domain_key domain key (domain_key can be any string like `sales`. There can be multiple domain key specified. |
 | `domain.domain_key.deny`        |          |              | List of regex patterns for tables to not assign domain_key. There can be multiple domain key specified.                                               |
 | `domain.domain_key.ignoreCase`  |          | `True`       | Whether to ignore case sensitivity during pattern matching.There can be multiple domain key specified.                                                       |
+| `catalog_id`  |          |              | The aws account id where the target glue catalog lives. If None, datahub will ingest glue in aws caller's account.                                                       |
 
 ## Compatibility
 

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -73,6 +73,7 @@ class GlueSourceConfig(AwsSourceConfig, PlatformSourceConfigBase):
     emit_s3_lineage: bool = False
     glue_s3_lineage_direction: str = "upstream"
     domain: Dict[str, AllowDenyPattern] = dict()
+    catalog_id: Optional[str] = None
 
     @property
     def glue_client(self):
@@ -162,7 +163,13 @@ class GlueSource(Source):
 
         # see https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/glue.html#Glue.Client.get_jobs
         paginator = self.glue_client.get_paginator("get_jobs")
-        for page in paginator.paginate():
+
+        if self.source_config.catalog_id:
+            paginator_response = paginator.paginate(CatalogId=self.source_config.catalog_id)
+        else:
+            paginator_response = paginator.paginate()
+
+        for page in paginator_response:
             jobs += page["Jobs"]
 
         return jobs
@@ -495,7 +502,14 @@ class GlueSource(Source):
 
             # see https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/glue.html#Glue.Client.get_tables
             paginator = self.glue_client.get_paginator("get_tables")
-            for page in paginator.paginate(DatabaseName=database_name):
+
+            if self.source_config.catalog_id:
+                paginator_response = paginator.paginate(DatabaseName=database_name,
+                                                    CatalogId=self.source_config.catalog_id)
+            else:
+                paginator_response = paginator.paginate(DatabaseName=database_name)
+
+            for page in paginator_response:
                 new_tables += page["TableList"]
 
             return new_tables
@@ -505,7 +519,13 @@ class GlueSource(Source):
 
             # see https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/glue.html#Glue.Client.get_databases
             paginator = self.glue_client.get_paginator("get_databases")
-            for page in paginator.paginate():
+
+            if self.source_config.catalog_id:
+                paginator_response = paginator.paginate(CatalogId=self.source_config.catalog_id)
+            else:
+                paginator_response = paginator.paginate()
+
+            for page in paginator_response:
                 for db in page["DatabaseList"]:
                     if self.source_config.database_pattern.allowed(db["Name"]):
                         database_names.append(db["Name"])


### PR DESCRIPTION
Added an optional field `catalog_id` to allow cross-account glue ingestion
tested ingestion successfully in local ENV
unit test passed except one ERROR in `tests/unit/test_airflow.py` that says `ImportError: cannot import name 'gen' from 'tornado' (unknown location)`


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.